### PR TITLE
Directory_watch_update

### DIFF
--- a/MAIN/Handler_PAI_float_report.py
+++ b/MAIN/Handler_PAI_float_report.py
@@ -25,6 +25,7 @@ FILENAME_STRINGS_TO_MATCH = [
     "Terminal Status(w_FLOAT)automated",
     "floatautomated_3_",
     "terminal_statuswfloatautomated",
+    "report_results_daily_float_report"  # this is a JSON file so it will not match this handler in it's current configuration
     ]
 
 ARCHIVE_DIRECTORY_NAME = "FloatReportArchive"

--- a/MAIN/Handler_PAI_float_report.py
+++ b/MAIN/Handler_PAI_float_report.py
@@ -88,7 +88,7 @@ def data_handler_process(file_path: Path):
         return False
 
     file_size = file_path.stat().st_size
-    logger.info(f"Starting processing for file: {file_path}, Size: {file_size} bytes")
+    logger.debug(f"Starting processing for file: {file_path}, Size: {file_size} bytes")
 
     logger.debug(f"Looking for date string in: {file_path.stem}")
     try:
@@ -121,7 +121,7 @@ def data_handler_process(file_path: Path):
     try:
         logger.debug(f"Applying formatting rules to result with {len(result)} records")
         apply_excel_formatting_to_dataframe_and_save_spreadsheet(output_file, result)
-        logger.info(f"Successfully saved formatted data to: {output_file}")
+        logger.debug(f"Successfully saved formatted data to: {output_file}")
     except Exception as e:
         logger.error(f"Error applying formatting or saving the file: {output_file}, Error: {e}")
         return False
@@ -133,20 +133,20 @@ def data_handler_process(file_path: Path):
     try:
         logger.debug(f"Sending Excel file to printer: {output_file}")
         print_excel_file(output_file)
-        logger.info(f"Excel file {output_file} sent to printer successfully")
+        logger.debug(f"Excel file {output_file} sent to printer successfully")
     except Exception as e:
         logger.error(f"Error printing file: {output_file}, Error: {e}")
         return False
 
     # Archive the original file
     try:
-        logger.info(f"Archiving original file from {file_path} to {input_file_archive_destination}")
+        logger.info(f"Archiving original file from {file_path.name} to {input_file_archive_destination.stem}")
         archive_original_file(file_path, input_file_archive_destination)
     except Exception as e:
         logger.error(f"Error archiving file: {file_path}, Error: {e}")
         return False
 
-    logger.info(f"All processing for file: {file_path} completed successfully")
+    logger.info(f"All processing for file: {file_path.name} completed successfully")
     return True
 
 

--- a/MAIN/directory_watcher.py
+++ b/MAIN/directory_watcher.py
@@ -37,16 +37,18 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
 
 
     directory_to_watch = Path(directory_to_watch)
-    pickle_file = Path(pickle_file)
+    # pickle_file = Path(pickle_file)
     ignore_SUFFIXs = ignore_SUFFIXs or []  # This is a good way to avoid the mutable variable problem
     #logger.debug(f'Checking watched directory {directory_to_watch} for new files while ignoring {ignore_SUFFIXs}')
 
+    """
     # Load existing filenames from pickle
     if pickle_file.exists():
         with pickle_file.open('rb') as pf:
             existing_files = pickle.load(pf)
     else:
         existing_files = set()
+    """
 
     # Update the list of files in the directory
     try:
@@ -55,7 +57,7 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
         logger.error(f'Could not access directory: {e}')
         sys.exit(0)  # TODO re-raise error
 
-    new_files = {f for f in current_files if f.name not in existing_files and f.is_file()}
+    new_files = {f for f in current_files if f.is_file()}
 
     if new_files == {}:
         logger.debug("No new files found.")
@@ -72,10 +74,12 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
         new_file_path = new_file
         logger.debug(f"New file found '{new_file.name}' in '{directory_to_watch.name}'")
 
+        """
         # Update the pickle file with the new filename
         existing_files.add(new_file)
         with pickle_file.open('wb') as pf:
             pickle.dump(existing_files, pf)
+        """
 
         if new_file.suffix in ignore_SUFFIXs:
             logger.debug('Ignoring.')  
@@ -88,11 +92,13 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
         new_file.rename(new_file_path)
         logger.debug(f"Renamed file: {new_file.name} -> {new_file_path}")
         
+        """
         # Update the pickle file with the new filename
         existing_files.add(new_file_path)
         with pickle_file.open('wb') as pf:
             pickle.dump(existing_files, pf)
-
+        """
+        
         return str(new_file_path)
     return None
 

--- a/MAIN/directory_watcher.py
+++ b/MAIN/directory_watcher.py
@@ -72,7 +72,7 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
     # Process the first new file
     for new_file in new_files:
         new_file_path = new_file
-        logger.debug(f"New file found '{new_file.name}' in '{directory_to_watch.name}'")
+        logger.info(f"New file found '{new_file.name}' in '{directory_to_watch.name}'")
 
         """
         # Update the pickle file with the new filename
@@ -98,7 +98,7 @@ def get_first_new_file(directory_to_watch, pickle_file, ignore_SUFFIXs=None):
         with pickle_file.open('wb') as pf:
             pickle.dump(existing_files, pf)
         """
-        
+
         return str(new_file_path)
     return None
 


### PR DESCRIPTION
Refactored code for handling of files within the watched directory and the logic around changing filenames to avoid conflicts. Removed use of a pickle file to track seen filenames since now all files are moved to an archive directory after being seen in the watched directory.